### PR TITLE
Added empty line to POD to fix markup on metacpan

### DIFF
--- a/lib/Env/Assert.pm
+++ b/lib/Env/Assert.pm
@@ -41,6 +41,7 @@ though not likely.
 
 
 =head1 SYNOPSIS
+
     use Env::Assert qw( assert );
 
     my %want = (


### PR DESCRIPTION
Here is a screenshot from https://metacpan.org/pod/Env::Assert that shows the problem:

![Screen Shot 2023-02-25 at 12 57 13](https://user-images.githubusercontent.com/47263/221350903-1db97a3d-3e12-43bc-9fb9-417542783cd9.png)

